### PR TITLE
Fix the problem and recover sqllin-dsl Kotlin/Native unit tests in CI/CD

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:assemble
 
-      #- name: Run sqllin-dsl macOS X64 Tests
-        #run: ./test_dsl_macos.sh
+      - name: Run sqllin-dsl macOS X64 Tests
+        run: ./test_dsl_macos.sh
 
       - name: Run Android 12 Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -101,8 +101,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:mingwX64MainKlibrary && ./gradlew :sqllin-dsl:mingwX86MainKlibrary
 
-      #- name: Run sqllin-dsl MinGW X64 Tests
-        #run: ./gradlew :sqllin-dsl:cleanMingwX64Test && ./gradlew :sqllin-dsl:mingwX64Test --stacktrace
+      - name: Run sqllin-dsl MinGW X64 Tests
+        run: ./gradlew :sqllin-dsl:cleanMingwX64Test && ./gradlew :sqllin-dsl:mingwX64Test --stacktrace
 
       - name: Upload sqllin-driver Reports
         uses: actions/upload-artifact@v2
@@ -150,8 +150,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:assemble
 
-      #- name: Run sqllin-dsl Linux X64 Tests
-        #run: ./gradlew :sqllin-dsl:cleanLinuxX64Test && ./gradlew :sqllin-dsl:linuxX64Test --stacktrace
+      - name: Run sqllin-dsl Linux X64 Tests
+        run: ./gradlew :sqllin-dsl:cleanLinuxX64Test && ./gradlew :sqllin-dsl:linuxX64Test --stacktrace
 
       - name: Run Android 8 Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,8 +41,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:assemble
 
-      #- name: Run sqllin-dsl macOS X64 Tests
-        #run: ./test_dsl_macos.sh
+      - name: Run sqllin-dsl macOS X64 Tests
+        run: ./test_dsl_macos.sh
 
       - name: Run Android Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2
@@ -99,8 +99,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:mingwX64MainKlibrary && ./gradlew :sqllin-dsl:mingwX86MainKlibrary
 
-      #- name: Run sqllin-dsl MinGW X64 Tests
-        #run: ./gradlew :sqllin-dsl:cleanMingwX64Test && ./gradlew :sqllin-dsl:mingwX64Test --stacktrace
+      - name: Run sqllin-dsl MinGW X64 Tests
+        run: ./gradlew :sqllin-dsl:cleanMingwX64Test && ./gradlew :sqllin-dsl:mingwX64Test --stacktrace
 
       - name: Upload sqllin-driver Reports
         uses: actions/upload-artifact@v2
@@ -151,8 +151,8 @@ jobs:
       - name: Build sqllin-dsl
         run: ./gradlew :sqllin-dsl:assemble
 
-      #- name: Run sqllin-dsl Linux X64 Tests
-        #run: ./gradlew :sqllin-dsl:cleanLinuxX64Test && ./gradlew :sqllin-dsl:linuxX64Test --stacktrace
+      - name: Run sqllin-dsl Linux X64 Tests
+        run: ./gradlew :sqllin-dsl:cleanLinuxX64Test && ./gradlew :sqllin-dsl:linuxX64Test --stacktrace
 
       - name: Run Android 8 Instrumentation Tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,6 @@ mavenRepositoryURL=https://oss.sonatype.org/service/local/staging/deploy/maven2
 #Gradle
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=16g -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
-org.gradle.configureondemand=true
 org.gradle.workers.max=16
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
Fix the problem about using KSP in Kotlin/Native unit tests and resume the sqllin-dsl Kotlin/Native unit tests in CI/CD.